### PR TITLE
Remove the ternary operator which checks if the user is a friend.

### DIFF
--- a/OGTrustRanks.cs
+++ b/OGTrustRanks.cs
@@ -102,12 +102,12 @@ namespace OGTrustRanks
                     TrustRanks rank = GetTrustRankEnum(__0);
                     if (rank == TrustRanks.LEGENDARY)
                     {
-                        __result = (APIUser.IsFriendsWith(__0.id) ? "Friend (Legendary User)" : "Legendary User");
+                        __result = "Legendary User";
                         return false;
                     }
                     else if (rank == TrustRanks.VETERAN)
                     {
-                        __result = (APIUser.IsFriendsWith(__0.id) ? "Friend (Veteran User)" : "Veteran User");
+                        __result = "Veteran User";
                         return false;
                     }
                 }


### PR DESCRIPTION
This caused a bug which would show "Friend (Friend (Veteran User))" as the user's Trust Level.